### PR TITLE
Replace Snyk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags: ["v*"]
   pull_request:
     branches: [ main ]
   schedule:
@@ -18,25 +19,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Build the Docker image snapshot
+
+    - name: Build the Docker image
       run: make build
-    - name: Run Snyk to check Docker image for vulnerabilities
-      # Snyk can be used to break the build when it detects vulnerabilities.
-      # In this case we want to upload the issues to GitHub Code Scanning
+
+    - name: Run Trivy vulnerability scanner
       continue-on-error: true
-      uses: snyk/actions/docker@master
-      env:
-        # In order to use the Snyk Action you will need to have a Snyk API token.
-        # More details in https://github.com/snyk/actions#getting-your-snyk-token
-        # or you can signup for free at https://snyk.io/login
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      uses: aquasecurity/trivy-action@master
       with:
-        image: ghcr.io/stonesoupkitchen/github-publisher
-        args: --file=Dockerfile
-    - name: Upload result to GitHub Code Scanning
+        image-ref: ghcr.io/stonesoupkitchen/github-publisher:latest
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: 'os,library'
+        severity: 'CRITICAL,HIGH'
+
+    - name: Upload scan results to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v2
       with:
-        sarif_file: snyk.sarif
+        sarif_file: 'trivy-results.sarif'
 
   release:
     name: Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,27 +33,17 @@
 FROM alpine:3.16.2 as builder
 
 RUN apk add --update --no-cache go rust cargo
-RUN cargo install git-cliff \
+RUN set -x \
+  && cargo install git-cliff \
   && go install github.com/tcnksm/ghr@latest
 
 #//////////////////////////////////////////////////////////////////////////////
 
 FROM alpine:3.16.2
-LABEL maintainer="joshua.ford@protonmail.com"
 
-# Container metadata
-ARG BUILD_DATE
-ARG GIT_REF
-
-LABEL org.opencontainers.image.created=$BUILD_DATE
-LABEL org.opencontainers.image.title="stonesoupkitchen/github-publisher"
-LABEL org.opencontainers.image.description="Create and publish releases to GitHub"
-LABEL org.opencontainers.image.url="https://github.com/stonesoupkitchen/container-github-publisher"
-LABEL org.opencontainers.image.source="https://github.com/stonesoupkitchen/container-github-publisher"
-LABEL org.opencontainers.image.revision=$GIT_REF
-
-RUN apk add --no-cache bash ca-certificates curl git make python3 py3-pip \
-  && pip3 install git-semver \
+RUN set -x \
+  && apk add --no-cache bash ca-certificates curl git make python3 py3-pip \
+  && pip3 install --no-cache-dir git-semver \
   && mkdir -p /opt/ssk/git-cliff
 
 COPY --from=builder /root/.cargo/bin/git-cliff /usr/bin/git-cliff


### PR DESCRIPTION
### Current behavior

Snyk scan results fail because of the change in their auth structure.

### Proposed changes

Instead of continuing to rely on Snyk, switch to Trivy to generate SARIF scan results.
