### PR TITLE
fix(ci): Run release job when tags are pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     permissions:
       packages: write
     needs: [Build]
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'push' && contains(github.ref, 'refs/tags'))
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Current behavior

Releases are only done on the main branch.

### Proposed behavior

Alter the Actions workflow so that releases are performed when tags are pushed.